### PR TITLE
chore(ci): add cargo deny check to CI

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -34,10 +34,6 @@ jobs:
           toolchain: stable
           override: true
 
-      # Generate Cargo.lock, needed for the cache.
-      - name: Generate lockfile
-        run: cargo generate-lockfile
-
       # Cache.
       - name: Cargo cache registry, index and build
         uses: actions/cache@v2

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -36,6 +36,7 @@ jobs:
 
       # Cache.
       - name: Cargo cache registry, index and build
+        if: matrix.os != 'macOS-latest'
         uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,6 +31,7 @@ jobs:
 
       # Cache.
       - name: Cargo cache registry, index and build
+        if: matrix.os != 'macOS-latest'
         uses: actions/cache@v2
         with:
           path: |
@@ -62,6 +63,7 @@ jobs:
 
       # Cache.
       - name: Cargo cache registry, index and build
+        if: matrix.os != 'macOS-latest'
         uses: actions/cache@v2
         with:
           path: |
@@ -104,6 +106,7 @@ jobs:
 
       # Cache.
       - name: Cargo cache registry, index and build
+        if: matrix.os != 'macOS-latest'
         uses: actions/cache@v2
         with:
           path: |
@@ -133,6 +136,7 @@ jobs:
 
       # Cache.
       - name: Cargo cache registry, index and build
+        if: matrix.os != 'macOS-latest'
         uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,10 +29,6 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-      # Generate Cargo.lock, needed for the cache.
-      - name: Generate Cargo.lock
-        run: cargo generate-lockfile
-
       # Cache.
       - name: Cargo cache registry, index and build
         uses: actions/cache@v2
@@ -63,10 +59,6 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-
-      # Generate Cargo.lock, needed for the cache.
-      - name: Generate Cargo.lock
-        run: cargo generate-lockfile
 
       # Cache.
       - name: Cargo cache registry, index and build
@@ -110,10 +102,6 @@ jobs:
           toolchain: stable
           override: true
 
-      # Generate Cargo.lock, needed for the cache.
-      - name: Generate lockfile
-        run: cargo generate-lockfile
-
       # Cache.
       - name: Cargo cache registry, index and build
         uses: actions/cache@v2
@@ -143,10 +131,6 @@ jobs:
           toolchain: stable
           override: true
 
-      # Generate Cargo.lock, needed for the cache.
-      - name: Generate lockfile
-        run: cargo generate-lockfile
-
       # Cache.
       - name: Cargo cache registry, index and build
         uses: actions/cache@v2
@@ -174,7 +158,18 @@ jobs:
           override: true
 
       # Install and run cargo udeps to find unused cargo dependencies
-      - name: cargo-udeps duplicate dependency check
+      - name: cargo-udeps unused dependency check
         run: |
           cargo install cargo-udeps --locked
           cargo +nightly udeps --all-targets
+
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    # wget the shared deny.toml file from the QA repo
+    - shell: bash
+      run: wget https://raw.githubusercontent.com/maidsafe/QA/master/misc-scripts/deny.toml
+
+    - uses: EmbarkStudios/cargo-deny-action@v1


### PR DESCRIPTION
This fetches a shared deny.toml from the QA repo before running the cargo deny GH Action.
This PR also makes a couple of negligible changes to CI/CD files.