### PR TITLE
fix: keep connection object around to avoid premature close 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,16 +13,17 @@ name = "brb_node"
 path = "src/brb_node.rs"
 
 [dependencies]
-rand = "0.8.2"
-serde = "1.0.120"
+rand = "0.8.3"
+serde = "1.0.123"
 bincode = "1.3.1"
-brb = "1.0.1"
-brb_dt_orswot = "1.0.1"
+brb = "1.0.2"
+brb_dt_orswot = "1.0.3"
 cmdr = "0.3.12"
-qp2p = "0.9.9"
-log = "0.4.13"
+qp2p = "0.9.13"
+log = "0.4.14"
 env_logger = "0.8.2"
+futures = "0.3.12"
 
-  [dependencies.tokio]
-  version = "~0.2.22"
-  features = [ "full" ]
+[dependencies.tokio]
+version = "~0.2.22"
+features = [ "full" ]


### PR DESCRIPTION
...and dropped packets.  See https://github.com/maidsafe/qp2p/issues/207

This fixes an issue where packets were being dropped and thus BRB processes sometimes would not complete.

feat: resolve "me" to self.state.actor() so that "trust me" shortcut command works
chore: update Cargo deps to latest versions