### PR TITLE
chore(cicd): remove publish steps from CI/CD pipeline

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -51,29 +51,3 @@ jobs:
       # Make sure the code builds.
       - name: Run cargo build
         run: cargo build --release --workspace
-
-  # Publish if we're on a release commit
-  publish:
-    name: Publish
-    runs-on: ubuntu-latest
-    needs: build
-    if: "startsWith(github.event.head_commit.message, 'chore(release):')"
-    steps:
-      - uses: actions/checkout@v2
-      # checkout with fetch-depth: '0' to be sure to retrieve all commits to look for the semver commit message
-        with:
-          fetch-depth: '0'
-     
-      # Install Rust
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      # Publish to crates.io.
-      - name: Cargo Login
-        run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
-
-      - name: Cargo Publish
-        run: cargo publish --allow-dirty

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -178,20 +178,3 @@ jobs:
         run: |
           cargo install cargo-udeps --locked
           cargo +nightly udeps --all-targets
-
-  # Test publish using --dry-run.
-  test-publish:
-    name: Test Publish
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - name: Test publish
-        run: cargo publish --dry-run --allow-dirty


### PR DESCRIPTION
As this crate is for an executable rather than a library, publishing to crates.io is unnecessary.